### PR TITLE
プロフィール情報から支援の情報を提示

### DIFF
--- a/app/tokyoto_app/app/controllers/profiles_controller.rb
+++ b/app/tokyoto_app/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :update]
+  before_action :set_user, only: [:show, :edit, :update, :user_supports]
 
   def new
     @user = User.new
@@ -17,7 +17,7 @@ class ProfilesController < ApplicationController
   end
 
   def show; end
-  
+
   def edit
     @cities = City.all
   end
@@ -29,6 +29,10 @@ class ProfilesController < ApplicationController
       flash.now[:alert] = 'プロフィールを更新できませんでした'
       render :edit
     end
+  end
+
+  def user_supports
+    @user_supports = ConditionsSupport.joins(:income, :age).where(city_id: @user.city_id, incomes: { money: @user.income..}, ages: {min: ..@user.children.first.age, max: @user.children.first.age..})
   end
 
   private

--- a/app/tokyoto_app/app/views/profiles/user_supports.html.erb
+++ b/app/tokyoto_app/app/views/profiles/user_supports.html.erb
@@ -1,0 +1,22 @@
+<% @user_supports.each do |user_support| %>
+  <section class="mb-6">
+    <div class="max-w-7xl px-8 py-4 bg-white rounded-lg shadow-md dark:bg-gray-800">
+      <div class="flex items-center justify-between border-black-600">
+          <a class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-600 rounded cursor-pointer hover:bg-gray-500">助成金</a>
+      </div>
+      <div class="mt-2">
+        <%= link_to "#{user_support.support.support_name}", top_path(user_support.support), class: "text-2xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline" %>
+      </div>
+      <div class="flex items-center justify-between mt-4">
+          <%= link_to "公式サイト", user_support.support.url, class: "text-blue-600 dark:text-blue-400 hover:underline" %>
+          <div class="font-bold text-gray-700 cursor-pointer dark:text-gray-200">
+            <% if user_support.support.application_limit.empty? %>
+              <%= "締め切り： なし" %>
+            <% else %>
+              <%= "締め切り：" + user_support.support.application_limit %>
+            <% end %>
+          </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/tokyoto_app/config/routes.rb
+++ b/app/tokyoto_app/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :top, only: %i[index show]
   resources :users, only: %i[new create]
   resource :profile
+  get "user_supports", to: "profiles#user_supports"
   get "hospitals/index", to: "hospitals#index"
   get "hospitals/search", to: "hospitals#search"
   get "map/hospitals", to: "map/hospitals#index"


### PR DESCRIPTION
プロフィール情報（地区・所得額・子どもの年齢）の条件で受給できる支援を一覧で表示する機能を作成しました。
まだ親に対して子どもが一人の場合でしか対応していません。
この実装方法が良ければ、今後子どもが複数いる場合に対応できるようにしていこうと思っています。