### PR TITLE
制度一覧表示時のタグ表示機能の追加

### DIFF
--- a/app/tokyoto_app/app/views/top/_result.html.erb
+++ b/app/tokyoto_app/app/views/top/_result.html.erb
@@ -3,7 +3,28 @@
   <section class="mb-6">
     <div class="max-w-7xl px-8 py-4 bg-white rounded-lg shadow-md dark:bg-gray-800">
       <div class="flex items-center justify-between border-black-600">
-          <a class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-600 rounded cursor-pointer hover:bg-gray-500">助成金</a>
+        <% case conditions_support.support.tag %>
+        <% when "医療" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-orange-400 rounded">
+            <%= conditions_support.support.tag %>
+          </p>
+        <% when "教育" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-teal-400 rounded">
+            <%= conditions_support.support.tag %>
+          </p>
+        <% when "住宅" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-blue-400 rounded">
+            <%= conditions_support.support.tag %>
+          </p>
+        <% when "育児" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-yellow-400 rounded">
+            <%= conditions_support.support.tag %>
+          </p>
+        <% else %>
+         <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-500 rounded">
+            <%= conditions_support.support.tag %>
+          </p>
+        <% end %>
       </div>
       <div class="mt-2">
         <%= link_to "#{conditions_support.support.support_name}", top_path(conditions_support.support), class: "text-2xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline" %>

--- a/app/tokyoto_app/app/views/top/_table.html.erb
+++ b/app/tokyoto_app/app/views/top/_table.html.erb
@@ -2,7 +2,28 @@
   <section class="mb-6">
     <div class="max-w-7xl px-8 py-4 bg-white rounded-lg shadow-md dark:bg-gray-800">
       <div class="flex items-center justify-between border-black-600">
-          <a class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-600 rounded cursor-pointer hover:bg-gray-500">助成金</a>
+        <% case support.tag %>
+        <% when "医療" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-orange-400 rounded">
+            <%= support.tag %>
+          </p>
+        <% when "教育" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-teal-400 rounded">
+            <%= support.tag %>
+          </p>
+        <% when "住宅" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-blue-400 rounded">
+            <%= support.tag %>
+          </p>
+        <% when "育児" then %>
+          <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-yellow-400 rounded">
+            <%= support.tag %>
+          </p>
+        <% else %>
+         <p class="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-500 rounded">
+            <%= support.tag %>
+          </p>
+        <% end %>
       </div>
       <div class="mt-2">
         <%= link_to "#{support.support_name}", top_path(support), class: "text-2xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline" %>

--- a/app/tokyoto_app/db/migrate/20221010023728_add_tag_to_support.rb
+++ b/app/tokyoto_app/db/migrate/20221010023728_add_tag_to_support.rb
@@ -1,0 +1,5 @@
+class AddTagToSupport < ActiveRecord::Migration[6.0]
+  def change
+    add_column :supports, :tag, :string
+  end
+end

--- a/app/tokyoto_app/db/schema.rb
+++ b/app/tokyoto_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_11_110230) do
+ActiveRecord::Schema.define(version: 2022_10_10_023728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2022_09_11_110230) do
     t.string "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "tag"
   end
 
   create_table "users", force: :cascade do |t|

--- a/app/tokyoto_app/db/seeds/development/supports.rb
+++ b/app/tokyoto_app/db/seeds/development/supports.rb
@@ -5,135 +5,152 @@ Support.create!(
       content: "18歳（18歳に達した最初の3月31日まで）のお子さん、あるいは規則に定める障害の状態にある20歳未満のお子さんを養育しているひとり親家庭の方（所得制限未満の方に限る）が、医療機関等で診療を受けた時に、 保険診療の自己負担分の一部もしくは全部を品川区が助成します。（通院・入院）",
       application_method: "申請を行う方により必要書類が異なるため、「子ども家庭部子ども家庭課育成支援係（区役所本庁舎2階16番窓口）」へ事前にご連絡をお願いします。交付申請をした日から助成の対象となります。公式HPを参照",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001247.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001247.html",
+      tag: "医療"
     },
     {
       support_name: "認証保育所・認可外保育施設の保育料助成",
       content: "都内の認証保育所・認可外保育施設（認証保育所を除く、一定の要件を満たす施設が対象）を利用する方の負担を軽減するため、保育料の助成を実施しています。",
-      application_method: "申請書を記入し、必要書類を添付して区に郵送していただくか、直接お持ちください。
-      ",
+      application_method: "申請書を記入し、必要書類を添付して区に郵送していただくか、直接お持ちください。",
       application_limit: "",
-      url: "https://www.city.shinjuku.lg.jp/kodomo/file03_04_00011.html"
+      url: "https://www.city.shinjuku.lg.jp/kodomo/file03_04_00011.html",
+      tag: "教育"
     },
     {
       support_name: "民間賃貸住宅家賃助成",
       content: "区内の民間賃貸住宅に住む世帯の家賃を助成することで負担を軽減し、定住化の促進を目的とした制度です。年に一度、期間を定めて子育てファミリー世帯向けの申し込みを受け付けます。",
       application_method: "",
       application_limit: "令和3年度の募集期間は、10月1日（金）から10月15日（金）",
-      url: "https://www.city.shinjuku.lg.jp/seikatsu/file07_02_00001.html"
+      url: "https://www.city.shinjuku.lg.jp/seikatsu/file07_02_00001.html",
+      tag: "住宅"
     },
     {
       support_name: "出産育児一時金",
       content: "新宿区の国民健康保険に加入している被保険者が出産したときに、出産育児一時金として42万円（出生児一人あたり）が支給されます。妊娠12週と1日（85日）以上の出産であれば、死産、流産の場合でも支給されます。",
       application_method: "公式HP参照",
       application_limit: "",
-      url: "https://www.city.shinjuku.lg.jp/hoken/file02_04_00007.html"
+      url: "https://www.city.shinjuku.lg.jp/hoken/file02_04_00007.html",
+      tag: "育児"
     },
     {
       support_name: "就学援助",
       content: "新宿区では、就学援助制度に基づき、経済的な理由から就学が困難と認められるご家庭に、学習に必要な費用の一部を援助しています。公立中学校夜間学級（夜間中学）に通学する生徒の方も、この制度を利用することができます。",
       application_method: "新宿区立小・中学校へお子さんが通学されている方は、学校に申請書がありますので、ご記入の上、必要書類（詳細は申請書に記載しています。）を添付して学校へご提出ください。",
       application_limit: "なし",
-      url: "https://www.city.shinjuku.lg.jp/kodomo/file04_04_00005.html"
+      url: "https://www.city.shinjuku.lg.jp/kodomo/file04_04_00005.html",
+      tag: "教育"
     },
     {
       support_name: "産後の家事育成助成",
       content: "産前産後に、育児や家事などの支援を必要とするご家庭に援助者（ヘルパー又は産後ドゥーラ）を派遣することによって、養育者の精神的・身体的負担を軽減し、産前産後の生活を支援をします。",
       application_method: "公式HP参照",
       application_limit: "なし",
-      url: "https://www.city.shinjuku.lg.jp/kodomo/file03_02_00001.html"
+      url: "https://www.city.shinjuku.lg.jp/kodomo/file03_02_00001.html",
+      tag: "育児"
     },
     {
       support_name: "私立幼稚園補助金",
       content: "新宿区内在住（住民登録をしていること）で、次の[1]又は[2]の園に通園する園児（満3歳児・3歳児・4歳児・5歳児）の保護者を対象に、国の幼児教育・保育の無償化制度に上乗せして入園料や保育料の補助金を交付します。",
       application_method: "郵送か窓口申請",
       application_limit: "",
-      url: "https://www.city.shinjuku.lg.jp/kodomo/file04_07_00003.html"
+      url: "https://www.city.shinjuku.lg.jp/kodomo/file04_07_00003.html",
+      tag: "教育"
     },
     {
       support_name: "児童扶養手当",
       content: "国の制度で、父または母と生計を同じくしていない児童が、養育される家庭の生活の安定と自立の促進に寄与し、児童の福祉の増進を図ることを目的としています。品川区内に住所があり、父母の離婚や死亡などにより母子家庭・父子家庭になった方や父母に重度の障害がある場合、または父母に養育されないなど以下の状態の児童（18歳に達した最初の3月31日までの児童、また中度以上の障害がある場合は20歳未満）を扶養している父・母または養育者に支給されます。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001248.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001248.html",
+      tag: "育児"
     },
     {
       support_name: "児童育成手当",
-      content: "児童の心身の健やかな成長に寄与し、児童福祉の増進を図ることを目的としています。児童育成手当を受けるためには申請が必要です。
-      ",
+      content: "児童の心身の健やかな成長に寄与し、児童福祉の増進を図ることを目的としています。児童育成手当を受けるためには申請が必要です。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001249.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000001249.html",
+      tag: "育児"
     },
     {
       support_name: "自立支援教育訓練給付金",
       content: "ひとり親家庭の経済的自立を促進するため、「就業に結びつきやすい技術や資格を得たい」「能力を高め増収を図りたい」というひとり親家庭のお母さんやお父さんに、次の給付金を支給します。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html",
+      tag: "就業支援"
     },
     {
       support_name: "ひとり親家庭住宅入居支援事業",
       content: "住宅に困窮するひとり親家庭に対して民間賃貸住宅への入居を支援するため、連帯保証人が立てられない方を対象として、保証会社に支払う「初回保証委託料」を助成します。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/20200116093231.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/20200116093231.html",
+      tag: "住宅"
     },
     {
       support_name: "東京都母子及び父子福祉資金",
       content: "ひとり親家庭の方々が経済的に自立して、安定した生活を送れるよう、母子・父子自立支援員が相談に応じ、審査のうえ、必要な資金を貸し付けます。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000030884.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000030884.html",
+      tag: "貸付金"
     },
     {
       support_name: "令和4年度低所得の子育て世帯生活支援特別給付金（ひとり親世帯分）",
       content: "新型コロナウイルス感染症による影響が長期化する中で 、食費等の物価高騰等に直面する低所得の子育て世帯に対し 、その実情を踏まえた生活の支援を行う観点から支給を行うものです。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/20220602092306.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/20220602092306.html",
+      tag: "給付金"
     },
     {
       support_name: "自立支援教育訓練給付金",
       content: "主体的な能力開発の取り組みを支援するため、母子家庭の母または父子家庭の父が対象の教育訓練を受講し修了した場合、経費の60％（12,001円～200,000円）を支給します。雇用保険法に基づく一般教育訓練給付金の支給を受けることができる方は、その支給額との差額を支給します。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html",
+      tag: "就業支援"
     },
     {
       support_name: "高等職業訓練促進給付金",
       content: "母子家庭の母または父子家庭の父が資格取得のため1年以上養成機関で修業する場合に、修業期間中の生活の負担軽減のため高等職業訓練促進給付金を支給するとともに、修了後には高等職業訓練修了支援給付金を支給します。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html",
+      tag: "就業支援"
     },
     {
       support_name: "高等職業訓練修了支援給付金",
       content: "母子家庭の母または父子家庭の父が資格取得のため1年以上養成機関で修業する場合に、修業期間中の生活の負担軽減のため高等職業訓練促進給付金を支給するとともに、修了後には高等職業訓練修了支援給付金を支給します。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000016382.html",
+      tag: "就業支援"
     },
     {
       support_name: "学習塾等受講料貸付金",
       content: "受験生チャレンジ支援貸付事業貸付金は、中学3年生とそれに準ずる方、高校3年生とそれに準ずる方を養育されている方に対して、学習塾などの費用や、高校や大学などの受験費用について貸付を行うことにより、一定所得以下の世帯の子どもへの支援を目的とした貸付金です。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-seikatsukomaru/hpg000004859.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-seikatsukomaru/hpg000004859.html",
+      tag: "教育"
     },
     {
       support_name: "受験料貸付金",
       content: "受験生チャレンジ支援貸付事業貸付金は、中学3年生とそれに準ずる方、高校3年生とそれに準ずる方を養育されている方に対して、学習塾などの費用や、高校や大学などの受験費用について貸付を行うことにより、一定所得以下の世帯の子どもへの支援を目的とした貸付金です。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-seikatsukomaru/hpg000004859.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-seikatsukomaru/hpg000004859.html",
+      tag: "教育"
     },
     {
       support_name: "養育費相談支援事業",
       content: "養育費相談では、大切な養育費を確実に確保するために、専門の相談員が相談に応じ、よりよい解決のための助言等を行っています。離婚を考えている方、養育費の取決めをしないまま離婚をした方、養育費の取決めはしたけれどもその後養育費を受け取れなくなっている方で、養育費を確実にするための支援を利用したいと考えている方はぜひご利用ください。",
       application_method: "",
       application_limit: "",
-      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000030880.html"
+      url: "https://www.city.shinagawa.tokyo.jp/PC/kodomo/kodomo-hitorioya/hpg000030880.html",
+      tag: "育児"
     },
   ]
 )


### PR DESCRIPTION
supportsテーブルにtagカラムを追加し、制度一覧表示時にtag名を表示するよう改良しました。
tagを複数個表示する場合は、中間テーブルを作成する必要があると思います。
私の力量では、手間がかかりそうなので、一旦１個表示にとどめます。