### PR TITLE
Municipality::Supportsのルーティング修正と追加 #56

### DIFF
--- a/app/tokyoto_app/config/routes.rb
+++ b/app/tokyoto_app/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
   
   namespace :municipality do
     resources :supports do
-      get "preview", on: :member
-      post "back", on: :member
+      post "preview", on: :collection
+      post "back", on: :collection
     end
     get "login", to: "municipality_sessions#new"
     post "login", to: "municipality_sessions#create"

--- a/app/tokyoto_app/config/routes.rb
+++ b/app/tokyoto_app/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
   
   namespace :municipality do
     resources :supports do
-      get "preview", to: "supports#preview"
-      post "back", to: "supports#back"
+      get "preview", on: :member
+      post "back", on: :member
     end
     get "login", to: "municipality_sessions#new"
     post "login", to: "municipality_sessions#create"

--- a/app/tokyoto_app/config/routes.rb
+++ b/app/tokyoto_app/config/routes.rb
@@ -14,10 +14,12 @@ Rails.application.routes.draw do
   get "map/hospitals", to: "map/hospitals#index"
   
   namespace :municipality do
-    resources :supports
+    resources :supports do
+      get "preview", to: "supports#preview"
+      post "back", to: "supports#back"
+    end
     get "login", to: "municipality_sessions#new"
     post "login", to: "municipality_sessions#create"
     delete "logout", to: "municipality_sessions#destroy"
-    get "preview", to: "supports#preview"
   end
 end


### PR DESCRIPTION
Municipality::Supportsのルーティングで指摘いただいた点の修正、および追加を行いました。
ご確認よろしくお願いします。

<修正点について>
preview画面のurlにidが付かない書き方だったため、supportsにネストさせました。

<追加点について>
「入力内容を修正するために新規作成画面に戻る」の操作をbackアクションとして追記しました。

通常この流れだと思いますが、
　制度新規作成(new)→確認画面(preview)→情報保存(create)→redirect→制度詳細画面(show)
確認画面を設けるということは、もう一度入力画面に戻る操作がいるのでは？と思いました。
　制度新規作成(new)→確認画面(preview)→入力内容を修正するために新規作成画面に戻る→確認画面(preview)→情報保存(create)→redirect→制度詳細画面(show)

参考：https://web-begginer-log.com/rails-confirm/