### PR TITLE
ransack使用部分のデフォルトキーをqueryに変更

### DIFF
--- a/app/tokyoto_app/app/controllers/top_controller.rb
+++ b/app/tokyoto_app/app/controllers/top_controller.rb
@@ -16,6 +16,6 @@ class TopController < ApplicationController
 
   private
   def set_query
-    @query = ConditionsSupport.ransack(params[:q])
+    @query = ConditionsSupport.ransack(params[:query])
   end
 end

--- a/app/tokyoto_app/app/controllers/top_controller.rb
+++ b/app/tokyoto_app/app/controllers/top_controller.rb
@@ -16,7 +16,6 @@ class TopController < ApplicationController
 
   private
   def set_query
-    # @q = ConditionsSupport.ransack(params[:q])
     @query = ConditionsSupport.ransack(params[:q])
   end
 end

--- a/app/tokyoto_app/app/controllers/top_controller.rb
+++ b/app/tokyoto_app/app/controllers/top_controller.rb
@@ -1,5 +1,5 @@
 class TopController < ApplicationController
-  before_action :set_q, only: [:index, :search]
+  before_action :set_query, only: [:index, :search]
   skip_before_action :require_login
 
   def index
@@ -7,7 +7,7 @@ class TopController < ApplicationController
   end
 
   def search
-    @results = @q.result
+    @results = @query.result
   end
 
   def show
@@ -15,7 +15,8 @@ class TopController < ApplicationController
   end
 
   private
-  def set_q
-    @q = ConditionsSupport.ransack(params[:q])
+  def set_query
+    # @q = ConditionsSupport.ransack(params[:q])
+    @query = ConditionsSupport.ransack(params[:q])
   end
 end

--- a/app/tokyoto_app/app/views/top/_search_form.html.erb
+++ b/app/tokyoto_app/app/views/top/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for @q, url: "/search" do |f| %>
+<%= search_form_for @query, url: "/search" do |f| %>
   <div class="flex flex-row space-x-4 mx-1 mb-3">
     <div class="flex-1">
       <%= f.label :support_support_name_cont, "制度名" , class: "block mb-2 text-xl font-medium text-gray-600 dark:text-gray-300" %>

--- a/app/tokyoto_app/config/initializers/ransack.rb
+++ b/app/tokyoto_app/config/initializers/ransack.rb
@@ -1,3 +1,4 @@
 Ransack.configure do |c|
   c.sanitize_custom_scope_booleans = false
+  c.search_key = :query
 end


### PR DESCRIPTION
@kuuwannya @yuki-sdy 
@qだと意味不明とのことだったので、@queryに変更しました。
挙動を確認したところ、制度名で絞り込みできていないみたいですが、これって正しい挙動ですか？
[![Image from Gyazo](https://i.gyazo.com/4c8886d80f5552712880d9d1425f89de.gif)](https://gyazo.com/4c8886d80f5552712880d9d1425f89de)

