### PR TITLE
退会機能の追加

### DIFF
--- a/app/tokyoto_app/app/controllers/users_controller.rb
+++ b/app/tokyoto_app/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
   def destroy
     @user = User.find(params[:id])
     @user.destroy
-    redirect_to :root, notice: 'ユーザーを削除しました。'
+    redirect_to :root, notice: '退会しました。'
   end
 
   private

--- a/app/tokyoto_app/app/controllers/users_controller.rb
+++ b/app/tokyoto_app/app/controllers/users_controller.rb
@@ -16,6 +16,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to :root, notice: 'ユーザーを削除しました。'
+  end
+
   private
 
   def user_params

--- a/app/tokyoto_app/app/views/profiles/show.html.erb
+++ b/app/tokyoto_app/app/views/profiles/show.html.erb
@@ -20,3 +20,5 @@
 
 <%= link_to  "プロフィールを編集する", edit_profile_path %>
 <%= link_to "トップページへ", top_index_path %>
+<%= link_to "退会する",user_path(current_user.id), method: :delete, "data-confirm" => "本当に退会しますか？" %>
+

--- a/app/tokyoto_app/config/routes.rb
+++ b/app/tokyoto_app/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   delete "logout", to: "user_sessions#destroy"
   get "search", to: "top#search"
   resources :top, only: %i[index show]
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create destroy]
   resource :profile
   get "user_supports", to: "profiles#user_supports"
   get "hospitals/index", to: "hospitals#index"

--- a/app/tokyoto_app/spec/rails_helper.rb
+++ b/app/tokyoto_app/spec/rails_helper.rb
@@ -22,7 +22,7 @@ SimpleCov.start 'rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -64,4 +64,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include LoginMacros
 end

--- a/app/tokyoto_app/spec/spec_helper.rb
+++ b/app/tokyoto_app/spec/spec_helper.rb
@@ -13,6 +13,7 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'capybara/rspec'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/app/tokyoto_app/spec/support/capybara.rb
+++ b/app/tokyoto_app/spec/support/capybara.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    # Spec実行時、ブラウザON
+    # driven_by(:selenium_chrome)
+    # Spec実行時、ブラウザOFF
+    # driven_by(:selenium_chrome_headless)
+    driven_by(:rack_test)
+  end
+end

--- a/app/tokyoto_app/spec/support/login_macros.rb
+++ b/app/tokyoto_app/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login(user)
+    visit login_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/app/tokyoto_app/spec/system/users_spec.rb
+++ b/app/tokyoto_app/spec/system/users_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Users", type: :system do
 
   describe '退会処理' do
     before { login(user) }
-    fit '退会するを選ぶと退会処理が行われて、トップページにリダイレクトされる' do
+    it '退会するを選ぶと退会処理が行われて、トップページにリダイレクトされる' do
       visit profile_path
       expect {
         click_link '退会する'
@@ -13,7 +13,7 @@ RSpec.describe "Users", type: :system do
 
       expect(current_path).to eq root_path
       within('header') {
-        expect(page).not_to have_content('さん')
+        expect(page).to have_content('新規登録')
       }
     end
   end

--- a/app/tokyoto_app/spec/system/users_spec.rb
+++ b/app/tokyoto_app/spec/system/users_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let(:user)  { create :user }
+
+  describe '退会処理' do
+    before { login(user) }
+    fit '退会するを選ぶと退会処理が行われて、トップページにリダイレクトされる' do
+      visit profile_path
+      expect {
+        click_link '退会する'
+      }.to change(User, :count).by(-1)
+
+      expect(current_path).to eq root_path
+      within('header') {
+        expect(page).not_to have_content('さん')
+      }
+    end
+  end
+end


### PR DESCRIPTION
@y-takagiiii @tsukudakouhei 
一般ユーザーが退会できるよう機能とリンクを実装して、システムテストを付与しました。
リンクはprofile_pathに配置したので、viewを編集される場合にはお気をつけください。

ちなみに、システムテストでは、退会後ヘッダーに「さん」が無いかをチェックしていますが
ちょっと格好悪いので、他の実装ができたらuser.nameやuser.nicknameにしたいと思っています…。