### PR TITLE
子供の生年月日を年齢に変換するメソッドを追記

### DIFF
--- a/app/tokyoto_app/app/models/child.rb
+++ b/app/tokyoto_app/app/models/child.rb
@@ -3,7 +3,7 @@ class Child < ApplicationRecord
 
   validates :birth, presence: true
 
-  def age(date)
-    (Date.today.strftime('%Y%m%d').to_i - date.strftime('%Y%m%d').to_i) / 10000
+  def age
+    (Date.today.strftime('%Y%m%d').to_i - birth.strftime('%Y%m%d').to_i) / 10000
   end
 end

--- a/app/tokyoto_app/app/models/child.rb
+++ b/app/tokyoto_app/app/models/child.rb
@@ -2,4 +2,8 @@ class Child < ApplicationRecord
   belongs_to :user
 
   validates :birth, presence: true
+
+  def age(date)
+    (Date.today.strftime('%Y%m%d').to_i - date.strftime('%Y%m%d').to_i) / 10000
+  end
 end

--- a/app/tokyoto_app/app/views/profiles/show.html.erb
+++ b/app/tokyoto_app/app/views/profiles/show.html.erb
@@ -3,9 +3,9 @@
 <div>ユーザーネーム <%= @user.user_name %>さん</div>
 <div>住んでいる地域 <%= show_city_name %></div>
 <div>収入（単位：万円）<%= show_income %>万円</div>
-<div>子供の生年月日
+<div>子どもの年齢
   <% @user.children.each do |child|%>
-    <%= child.birth %>
+    <%= child.age %>歳
   <% end %>
 </div>
 


### PR DESCRIPTION
今後実装予定にある「満○歳」の制度を検索できるように、
ユーザーが入力した子供の生年月日を年齢に変換するメソッドのみとなります。
よろしくお願いいたします。

### 動作確認について
プロフィールの詳細画面にて、childrenをeachで回している中で`<%= child.age %>`を追記して、
表示が確認できるかどうかをお確かめください。