### PR TITLE
新規DBのマイグレーションファイルにバリデーションを追加

### DIFF
--- a/app/tokyoto_app/db/migrate/20220911110230_create_children.rb
+++ b/app/tokyoto_app/db/migrate/20220911110230_create_children.rb
@@ -2,7 +2,7 @@ class CreateChildren < ActiveRecord::Migration[6.0]
   def change
     create_table :children do |t|
       t.references :user, null: false, foreign_key: true
-      t.date :birth
+      t.date :birth, null: false
 
       t.timestamps
     end

--- a/app/tokyoto_app/db/migrate/20221116133731_add_state_to_supports.rb
+++ b/app/tokyoto_app/db/migrate/20221116133731_add_state_to_supports.rb
@@ -1,5 +1,5 @@
 class AddStateToSupports < ActiveRecord::Migration[6.0]
   def change
-    add_column :supports, :publish_state, :integer, :null => false
+    add_column :supports, :publish_state, :integer, :null => false, :default => 0
   end
 end

--- a/app/tokyoto_app/db/migrate/20230102100226_create_conditions_supports.rb
+++ b/app/tokyoto_app/db/migrate/20230102100226_create_conditions_supports.rb
@@ -7,8 +7,8 @@ class CreateConditionsSupports < ActiveRecord::Migration[6.0]
       t.integer :payment, null: false
       t.references :age, null: false, foreign_key: true
       t.string :url, null: false
-      t.integer :payment_limit, default: 0
-      t.integer :payment_frequency, default: 0
+      t.integer :payment_limit, default: 0, null: false
+      t.integer :payment_frequency, default: 0, null: false
       t.string :payment_month
       t.string :transfer_destination
 

--- a/app/tokyoto_app/db/schema.rb
+++ b/app/tokyoto_app/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2023_02_17_112041) do
 
   create_table "children", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.date "birth"
+    t.date "birth", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_children_on_user_id"
@@ -52,8 +52,8 @@ ActiveRecord::Schema.define(version: 2023_02_17_112041) do
     t.integer "payment", null: false
     t.bigint "age_id", null: false
     t.string "url", null: false
-    t.integer "payment_limit", default: 0
-    t.integer "payment_frequency", default: 0
+    t.integer "payment_limit", default: 0, null: false
+    t.integer "payment_frequency", default: 0, null: false
     t.string "payment_month"
     t.string "transfer_destination"
     t.datetime "created_at", precision: 6, null: false
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2023_02_17_112041) do
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "publish_state", null: false
+    t.integer "publish_state", default: 0, null: false
     t.index ["support_name"], name: "index_supports_on_support_name", unique: true
   end
 


### PR DESCRIPTION
#119 でモデルテストを書いている際、
modelファイルとschemaファイルで記述が異なる箇所を見つけたので
マイグレーションファイルに以下3箇所を追記しています。

- Childのbirth　→　`null: false`を追加
- Conditions_supportのpayment_limit, payment_frequency　→　`null: false`を追加
- Supportのpublish_state　→　`default: 0`を追加

### 確認してほしいこと
- `bin/rails db:reset`を実行後、`bin/rails db:seed`でseedが適切に入ること。
- schema.rb にて3箇所のカラムに変更が反映されていること。