### PR TITLE
プロフィール登録時のバグ修正

### DIFF
--- a/app/tokyoto_app/app/controllers/profiles_controller.rb
+++ b/app/tokyoto_app/app/controllers/profiles_controller.rb
@@ -20,9 +20,13 @@ class ProfilesController < ApplicationController
       render :new
     end
   end
-
+  
   def show
-    @city = City.find(current_user.city_id)
+    if current_user.city_id.present?
+      @city = City.find(current_user.city_id)
+    else
+      redirect_to new_profile_path, alert: 'プロフィール情報を登録してください。'
+    end
   end
   
   def edit
@@ -66,15 +70,15 @@ class ProfilesController < ApplicationController
   end
 
   def set_public_assistance_situation
-    @public_assistance_situations = FamilySituation.where_public_assistance_situation
+    @public_assistance_situations = FamilySituation.load_public_assistance_situation
   end
 
   def set_dependency_situation
-    @dependency_situations = FamilySituation.where_dependency_situation
+    @dependency_situations = FamilySituation.load_dependency_situation
   end
 
   def set_child_situation
-    @child_situations = FamilySituation.where_child_situation
+    @child_situations = FamilySituation.load_child_situation
   end
 
   def set_cities

--- a/app/tokyoto_app/app/views/profiles/_form.html.erb
+++ b/app/tokyoto_app/app/views/profiles/_form.html.erb
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="space-y-1">
-    <%= f.label '子供の年齢' %>
+    <%= f.label '子供の生年月日' %>
     <div class="mt-1" id="children_birth_form">
       <% if births.empty? %>
         <div id="birth_0">

--- a/app/tokyoto_app/app/views/profiles/_form.html.erb
+++ b/app/tokyoto_app/app/views/profiles/_form.html.erb
@@ -39,11 +39,11 @@
   </div>
   <div class="space-y-1">
     <%= label_tag "生活保護の状況" %>
-    <%= select_tag "profile_form[public_assistance_situation]", options_from_collection_for_select(@public_assistance_situations, "id", "situation"), class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:border-transparent focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-300 border-gray-500" %>
+    <%= select_tag "profile_form[public_assistance_situation]", options_from_collection_for_select(@public_assistance_situations || FamilySituation.load_public_assistance_situation, "id", "situation"), class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:border-transparent focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-300 border-gray-500" %>
   </div>
   <div class="space-y-1">
     <%= label_tag '扶養人数の状況' %>
-    <%= select_tag "profile_form[dependency_situation]", options_from_collection_for_select(@dependency_situations, "id", "situation"), class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:border-transparent focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-300 border-gray-500" %>
+    <%= select_tag "profile_form[dependency_situation]", options_from_collection_for_select(@dependency_situations || FamilySituation.load_dependency_situation, "id", "situation"), class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:border-transparent focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-300 border-gray-500" %>
   </div>
   <%= f.submit '登録する', class: "flex items-center justify-center w-full px-10 py-4 text-base font-medium text-center text-white transition duration-500 ease-in-out transform bg-blue-600 rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
 <% end %>


### PR DESCRIPTION
プロフィール登録時のバグ修正が完了しましたので、レビューをお願いいたします。

### 確認してほしいこと
・プロフィール登録時に**収入**をブランクにすると「プロフィールを登録できませんでした。」とフラッシュが出る。
・プロフィール登録時に**子供の生年月日**をブランクにすると「プロフィールを登録できませんでした。」とフラッシュが出る。
・新規登録後、root_path等の画面に移ってプロフィール情報の登録を中断すると、マイページに遷移した時にプロフィール登録画面へリダイレクトされる。

### 謝罪
以下3つのメソッドの修正は、#136 の修正し忘れを誤って一緒にpushしてしまいました。
既にdevelopブランチはこの内容で変更されていますので今回は無視してください。
04581de956f606c610025b6496470088bb87e50d
・set_public_assistance_situation
・set_dependency_situation
・set_child_situation