### PR TITLE
incomeをmin,maxのカラムに合わせて検索できるように修正

### DIFF
--- a/app/tokyoto_app/app/controllers/top_controller.rb
+++ b/app/tokyoto_app/app/controllers/top_controller.rb
@@ -25,8 +25,8 @@ class TopController < ApplicationController
 
   def set_query
     @query = ConditionsSupport.ransack(params[:query])
-    params[:query][:incomes_money_gt] =
-      income_to_db(params[:query][:incomes_money_gt]) if !params[:query].nil?
+    params[:query][:income_search] =
+      income_to_db(params[:query][:income_search]) if !params[:query].nil?
     @query_fix = ConditionsSupport.ransack(params[:query])
   end
 end

--- a/app/tokyoto_app/app/models/conditions_support.rb
+++ b/app/tokyoto_app/app/models/conditions_support.rb
@@ -27,8 +27,9 @@ class ConditionsSupport < ApplicationRecord
   enum payment_frequency: { lump: 0, every_one_month: 1 , every_two_months: 2, every_three_months: 3, every_four_months: 4, non_listed: 5, no_transfers: 6 }
 
   scope :age_search, -> (number){ joins(:age).where("min <= ? and ? <= max", number, number)}
+  scope :income_search, -> (number){ joins(:incomes).where("min <= ? and ? <= max", number, number)}
 
   def self.ransackable_scopes(auth_object = nil)
-    %i[age_search]
+    %i[age_search income_search]
   end
 end

--- a/app/tokyoto_app/app/models/conditions_support.rb
+++ b/app/tokyoto_app/app/models/conditions_support.rb
@@ -26,8 +26,8 @@ class ConditionsSupport < ApplicationRecord
   enum payment_limit: { fixed_amount: 0, monthly_limit: 1 , upper_limit: 2, full_payment: 3, partial_payment: 4 }
   enum payment_frequency: { lump: 0, every_one_month: 1 , every_two_months: 2, every_three_months: 3, every_four_months: 4, non_listed: 5, no_transfers: 6 }
 
-  scope :age_search, -> (number){ joins(:age).where("min <= ? and ? <= max", number, number)}
-  scope :income_search, -> (number){ joins(:incomes).where("min <= ? and ? <= max", number, number)}
+  scope :age_search, -> (number){ joins(:age).where("ages.min <= ? and ? <= ages.max", number, number)}
+  scope :income_search, -> (number){ joins(:incomes).where("incomes.min <= ? and ? <= incomes.max", number, number)}
 
   def self.ransackable_scopes(auth_object = nil)
     %i[age_search income_search]

--- a/app/tokyoto_app/app/views/top/_result.html.erb
+++ b/app/tokyoto_app/app/views/top/_result.html.erb
@@ -12,16 +12,10 @@
       </div>
 
       <div class="mt-2">
-        <%= link_to "#{conditions_support.support.support_name}", top_path(conditions_support.support), class: "text-2xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline" %>
+        <%= link_to "#{conditions_support.support.support_name}", top_path(conditions_support), class: "text-2xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline" %>
       </div>
       <div class="flex items-center justify-between mt-4">
-          <%#= link_to "公式サイト", conditions_support.support.url, class: "text-blue-600 dark:text-blue-400 hover:underline" %>
           <div class="font-bold text-gray-700 cursor-pointer dark:text-gray-200">
-            <%# if conditions_support.support.user_application_limit.empty? %>
-              <%#= "締め切り： なし" %>
-            <%# else %>
-              <%#= "締め切り：" + conditions_support.support.user_application_limit %>
-            <%# end %>
           </div>
       </div>
     </div>

--- a/app/tokyoto_app/app/views/top/_search_form.html.erb
+++ b/app/tokyoto_app/app/views/top/_search_form.html.erb
@@ -9,8 +9,8 @@
       <%= f.search_field :city_city_name_cont, class: "block mb-4 p-4 w-full text-gray-900 bg-gray-50 rounded-lg border border-gray-300 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500",placeholder: "記入例（港区）" %>
     </div>
     <div class="flex-1">
-      <%= f.label :incomes_money_gt, "所得額" , class: "inline-block mb-2 text-xl font-medium text-gray-600 dark:text-gray-300" %><p class="inline-block">（単位：万円）<p>
-      <%#= f.number_field :incomes_money_gt, class: "block mb-4 p-4 w-full text-gray-900 bg-gray-50 rounded-lg border border-gray-300 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500",placeholder: "記入例（300）" %>
+      <%= f.label :income_search, "所得額" , class: "inline-block mb-2 text-xl font-medium text-gray-600 dark:text-gray-300" %><p class="inline-block">（単位：万円）<p>
+      <%= f.number_field :income_search, class: "block mb-4 p-4 w-full text-gray-900 bg-gray-50 rounded-lg border border-gray-300 sm:text-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500",placeholder: "記入例（300）" %>
     </div>
     <div class="flex-1">
       <%= f.label :age_search, "子供の年齢" , class: "block mb-2 text-xl font-medium text-gray-600 dark:text-gray-300" %>

--- a/app/tokyoto_app/db/seeds/development/conditions_supports_incomes.rb
+++ b/app/tokyoto_app/db/seeds/development/conditions_supports_incomes.rb
@@ -310,5 +310,66 @@ ConditionsSupportsIncome.create!(
       conditions_support_id: 73,
       income_id: 6
     },
+    #私立幼稚園等保護者補助金-生活保護-270万円以下
+    {
+      id: 62,
+      conditions_support_id: 2,
+      income_id: 2
+    },
+    {
+      id: 63,
+      conditions_support_id: 3,
+      income_id: 2
+    },
+    {
+      id: 64,
+      conditions_support_id: 4,
+      income_id: 2
+    },
+    {
+      id: 65,
+      conditions_support_id: 5,
+      income_id: 2
+    },
+    {
+      id: 66,
+      conditions_support_id: 6,
+      income_id: 2
+    },
+    {
+      id: 67,
+      conditions_support_id: 7,
+      income_id: 2
+    },
+    {
+      id: 68,
+      conditions_support_id: 8,
+      income_id: 2
+    },
+    {
+      id: 69,
+      conditions_support_id: 9,
+      income_id: 2
+    },
+    {
+      id: 70,
+      conditions_support_id: 10,
+      income_id: 2
+    },
+    {
+      id: 71,
+      conditions_support_id: 11,
+      income_id: 2
+    },
+    {
+      id: 72,
+      conditions_support_id: 12,
+      income_id: 2
+    },
+    {
+      id: 73,
+      conditions_support_id: 13,
+      income_id: 2
+    },
   ]
 )

--- a/app/tokyoto_app/db/seeds/development/income.rb
+++ b/app/tokyoto_app/db/seeds/development/income.rb
@@ -1,5 +1,6 @@
 Income.create!(
   [
+    #所得が関係ない場合
     { id: 1, min: 0, max: 1000000000, is_myself: 0 },
     #生活保護以上で270万円未満の場合
     { id: 2, min: 0, max: 2700000, is_myself: 1 },


### PR DESCRIPTION
### Issue
- #145

### エラー回避
scopeに二つ記載して上手くいかなかった理由
>PG::AmbiguousColumnエラーは、SQLクエリでカラム名が曖昧であるため、PostgreSQLがカラムを特定できない場合に発生します。これは、クエリに複数のテーブルが含まれている場合や、カラム名がテーブル間で重複している場合によく発生します。
エラーによると、minカラムが曖昧であるため、PostgreSQLが特定できません。このエラーを修正するためには、クエリのどこかでminカラムが使用されている場所を特定し、明示的に使用するテーブルを指定する必要があります。
このエラーが発生する可能性がある箇所は、age_searchスコープに関連しているクエリの部分です。age_searchスコープには、おそらくminというカラム名を含む条件が含まれているため、エラーが発生していると思われます。
修正方法は、SQLクエリのminカラムを特定するテーブルを明示的に指定することです。たとえば、agesテーブルにminカラムがある場合、クエリのminカラムにages.minのようにテーブル名を指定してください。これにより、PostgreSQLがカラムを特定できるようになり、エラーが解消されます。

要約するとminとmaxをageテーブルとincomeテーブルに使ったからどっちがどっちか分からなくなった。
⇨明示的にしてあげると上手くいった。

```
def self.ransackable_scopes(auth_object = nil)
  %i[age_search income_search]
end

# age_searchスコープ
scope :age_search, -> (min_age, max_age) do
  joins(:age).where("ages.min <= ? AND ages.max >= ?", max_age, min_age)
end

# income_searchスコープ
scope :income_search, -> (min_income, max_income) do
  where("income >= ? AND income <= ?", min_income, max_income)
end
```

## 確認してほしいこと
seedに入っているデータがきちんと検索フォームに入れたら漏れがなくヒットしているかの確認
・入園料金補助金（私立幼稚園) incomeの限度はない
・私立幼稚園等保護者補助金

<参考資料>
[台東区のHP](https://www.city.taito.lg.jp/kosodatekyouiku/yochien/shiritsuyochien/hogoshahojo.files/04hogoshahojo.pdf)
[支援のスプレッドシート](https://docs.google.com/spreadsheets/d/1NXF8JGTLz4cuPoJBckAhZCdrY6m7cXG36h6EMPOKJ-w/edit#gid=1185713360)