### PR TITLE
制度showページデザインを修正#147

### DIFF
--- a/app/tokyoto_app/app/helpers/conditions_support_show_helper.rb
+++ b/app/tokyoto_app/app/helpers/conditions_support_show_helper.rb
@@ -1,10 +1,10 @@
 module ConditionsSupportShowHelper
 
   def replace_head_of_line_to_interpoint(data)
-    data.sub(/^/, '・')
+    data.sub(/^/, '・') if data.present?
   end
 
   def replace_comma_to_interpoint(data)
-    data.gsub(/,/, '・')
+    data.gsub(/,/, '・') if data.present?
   end
 end

--- a/app/tokyoto_app/app/helpers/conditions_support_show_helper.rb
+++ b/app/tokyoto_app/app/helpers/conditions_support_show_helper.rb
@@ -1,0 +1,10 @@
+module ConditionsSupportShowHelper
+
+  def replace_head_of_line_to_interpoint(data)
+    data.sub(/^/, '・')
+  end
+
+  def replace_comma_to_interpoint(data)
+    data.gsub(/,/, '・')
+  end
+end

--- a/app/tokyoto_app/app/views/top/show.html.erb
+++ b/app/tokyoto_app/app/views/top/show.html.erb
@@ -1,4 +1,5 @@
 <div class="mx-5 my-10">
+<<<<<<< HEAD
     <section class= "mb-10 basic-info text-center">
         <h3 class= "font-bold text-4xl"><%= @conditions_support.support.support_name %></h3>
     </section>
@@ -145,6 +146,107 @@
                 </td>
             </tr>
         </tbody>
+=======
+  <section class= "mb-10 basic-info text-center">
+    <h3 class= "font-bold text-4xl"><%= @support.support_name %></h3>
+  </section>
+
+  <div class="font-bold text-2xl">申請できる条件は<span id="conditions-supports-count"><%= @support.conditions_supports.count %></span>種類あります。</div>
+  <h4 class= "font-bold text-2xl">条件の変更</h4>
+  <%= render partial: 'search_conditions_form', locals: { support_id: @support.id } %>
+  <% @support.conditions_supports.each do |conditions_support| %>
+    <table class="conditions-supports mb-10 table-fixed text-left text-gray-600" id="<%= conditions_support.id %>">
+      <thead class="text-sm text-center bg-gray-100">
+        <tr>
+          <th scope="col" class="w-1/6 py-3 px-6">
+            項目
+          </th>
+          <th scope="col" class="py-3 px-6 text-left">
+            内容
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            制度内容
+          </th>
+          <td class="py-4 px-6">
+            <%= @support.content %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            対象条件
+          </th>
+          <td class="py-4 px-6">
+            <% conditions_support.condition.statuses.each do |status| %>
+              <p>
+                <%= status.status %>
+              </p>
+            <% end %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            制度についての追記事項
+          </th>
+          <td class="py-4 px-6">
+            <% conditions_support.addinfo_conditions_supports.each do |addinfo_conditions_support| %>
+              <p>
+                <%= addinfo_conditions_support.info_content %>
+              </p>
+            <% end %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            申請方法
+          </th>
+          <td class="py-4 px-6">
+            <% conditions_support.application_methods.each do |application_method| %>
+              <p>
+                <%= application_method.application_method %>
+              </p>
+            <% end %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            申請期限
+          </th>
+
+          <td class="py-4 px-6">
+              <%= conditions_support.user_application_limit %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            地区名
+          </th>
+          <td class="py-4 px-6">
+            <%= conditions_support.city.city_name %>
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            支給額(年額)
+          </th>
+          <td class="py-4 px-6">
+            <%= conditions_support.payment %>円
+          </td>
+        </tr>
+        <tr class="border-b dark:bg-gray-800">
+          <th scope="row" class="py-4 px-6 font-bold text-center">
+            公式サイト
+          </th>
+          <td class="py-4 px-6">
+            <%= link_to conditions_support.url, conditions_support.url %>
+          </td>
+        </tr>
+      </tbody>
+>>>>>>> develop
     </table>
-    <%= link_to "制度一覧に戻る", root_path, class: "mx-10" %>
+  <% end %>
+  <%= link_to "制度一覧に戻る", root_path, class: "mx-10" %>
 </div>

--- a/app/tokyoto_app/app/views/top/show.html.erb
+++ b/app/tokyoto_app/app/views/top/show.html.erb
@@ -2,6 +2,17 @@
     <section class= "mb-10 basic-info text-center">
         <h3 class= "font-bold text-4xl"><%= @conditions_support.support.support_name %></h3>
     </section>
+    <div class="border-b dark:bg-gray-800">
+        <div class="flex justify-center items-center py-4 px-6">
+        <div class="text-3xl font-bold text-center mr-4">
+            支給額(年額)
+        </div>
+        <div class="text-5xl font-bold text-gray-700 dark:text-gray-400">
+            <%= number_to_currency(@conditions_support.payment, unit: '円', precision: 0) %>
+        </div>
+        </div>
+    </div>
+    </table>
     <table class="mb-10 table-fixed text-left text-gray-600">
         <thead class="text-sm text-center bg-gray-100">
             <tr>
@@ -28,7 +39,7 @@
                 </th>
                 <td class="py-4 px-6">
                     <% @conditions_support.condition.statuses.each do |status| %>
-                        <p><%= status.status %></p>
+                        <p class="mb-1"><%= replace_head_of_line_to_interpoint(status.status) %></p>
                     <% end %>
                 </td>
             </tr>
@@ -38,8 +49,8 @@
                 </th>
                 <td class="py-4 px-6">
                     <% @conditions_support.addinfo_conditions_supports.each do |addinfo_conditions_support| %>
-                        <p>
-                            <%= addinfo_conditions_support.info_content %>
+                        <p class="mb-3 border-b-2">
+                            <%= replace_head_of_line_to_interpoint(addinfo_conditions_support.info_content) %>
                         </p>
                     <% end %>
                 </td>
@@ -50,8 +61,8 @@
                 </th>
                 <td class="py-4 px-6">
                     <% @conditions_support.application_methods.each do |application_method| %>
-                        <p>
-                            <%= application_method.application_method %>
+                        <p class="mb-1">
+                            <%= replace_head_of_line_to_interpoint(application_method.application_method) %>
                         </p>
                     <% end %>
                 </td>
@@ -60,11 +71,24 @@
                 <th scope="row" class="py-4 px-6 font-bold text-center">
                     申請書類
                 </th>
+                
                 <td class="py-4 px-6">
                     <% @conditions_support.application_forms.each do |application_form| %>
-                        <p>
-                            <%= application_form.application_form_name %>
-                        </p>
+                            <p class="mb-1">
+                                <%= replace_head_of_line_to_interpoint(application_form.application_form_name) %> <br>
+                            </p>
+                    <% end %>
+                </td>
+            </tr>
+            <tr class="border-b dark:bg-gray-800">
+                <th scope="row" class="py-4 px-6 font-bold text-center">
+                    申請書類URL
+                </th>
+                <td class="py-4 px-6">
+                    <% @conditions_support.application_forms.each do |application_form| %>
+                            <p class="mb-1">
+                                <%= application_form.application_form_url %>
+                            </p>
                     <% end %>
                 </td>
             </tr>
@@ -78,22 +102,38 @@
             </tr>
             <tr class="border-b dark:bg-gray-800">
                 <th scope="row" class="py-4 px-6 font-bold text-center">
-                    申請についての追記事項
+                    更新方法
                 </th>
                 <td class="py-4 px-6">
-                    <% @conditions_support.addinfo_applications.each do |addinfo_application| %>
-                        <p>
-                            <%= addinfo_application.info_content %>
-                        </p>
-                    <% end %>
+                    <%= @conditions_support.user_renewal_method %>
                 </td>
             </tr>
             <tr class="border-b dark:bg-gray-800">
                 <th scope="row" class="py-4 px-6 font-bold text-center">
-                    支給額(年額)
+                    更新月
                 </th>
                 <td class="py-4 px-6">
-                    <%= @conditions_support.payment %>円
+                    <%= @conditions_support.user_renewal_month %>
+                </td>
+            </tr>
+            <tr class="border-b dark:bg-gray-800">
+                <th scope="row" class="py-4 px-6 font-bold text-center">
+                    お問い合わせ先
+                </th>
+                <td class="py-4 px-6">
+                    <%= replace_comma_to_interpoint(@conditions_support.contact_information) %>
+                </td>
+            </tr>
+            <tr class="border-b dark:bg-gray-800">
+                <th scope="row" class="py-4 px-6 font-bold text-center">
+                    申請についての追記事項
+                </th>
+                <td class="py-4 px-6">
+                    <% @conditions_support.addinfo_applications.each do |addinfo_application| %>
+                        <p class="mb-1">
+                            <%= replace_head_of_line_to_interpoint(addinfo_application.info_content) %>
+                        </p>
+                    <% end %>
                 </td>
             </tr>
             <tr class="border-b dark:bg-gray-800">


### PR DESCRIPTION
制度のshowページを一旦以下に修正しました！！！

- showページ上部に支給額を表示
-  以下項目などの複数データがある項目の行頭に「・」をつけた。

対象条件、 制度についての追記事項など

-  制度についての追記事項に下線をつける
- 申請書類URLの項目追加
- お問い合わせ先の「,」を「・」に変換
![show画面デザイン](https://user-images.githubusercontent.com/98330232/225279373-daa4cf66-54be-46cc-a057-e695f25714b4.png)


正直色々考えたけど、そこまでいいデザインがでなかった。。。
